### PR TITLE
Easier installation with launchd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,28 +22,13 @@ Used to accept (or deny) the use of the private key(s) added to the SSH authenti
 
 ### Without Homebrew
 
-#### Pre 10.11
+* Run:
 ```
-$ sudo ln -s $PWD/ssh-askpass /usr/libexec/ssh-askpass
+$ sudo cp ssh-askpass /usr/local/bin/
+$ cp ssh-askpass.plist ~/Library/LaunchAgents/
+
 ```
-#### 10.11+
-
-* If you have XQuartz (http://www.xquartz.org/) or are willing to get it:
-    * Make sure that the latest XQuartz is installed. (eg. brew cask install xquartz)
-    * Run:
-
-    ```
-    $ sudo ln -s /usr/local/bin/ssh-askpass /usr/X11R6/bin/ssh-askpass
-    ```
-* Else:
-    * [Disable SIP (rootless)](http://www.imore.com/el-capitan-system-integrity-protection-helps-keep-malware-away)
-    * Run:
-
-    ```
-    $ sudo mkdir -p /usr/X11R6/bin
-    $ sudo ln -s $PWD/ssh-askpass /usr/X11R6/bin/ssh-askpass
-    ```
-    * [Enable SIP (rootless)](http://www.imore.com/el-capitan-system-integrity-protection-helps-keep-malware-away)
+* Log out and in (reboot preferrd) before you can add keys to the agent with `ssh-add -c`
 
 ## Enabling keyboard navigation
 For security reasons ssh-askpass defaults to cancel since it's too easy to

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Used to accept (or deny) the use of the private key(s) added to the SSH authenti
 $ sudo cp ssh-askpass /usr/local/bin/
 $ cp ssh-askpass.plist ~/Library/LaunchAgents/
 ```
-* Log out and in (reboot preferrd) before you can add keys to the agent with `ssh-add -c`
+* Log out and in before you can add keys to the agent with `ssh-add -c`
 
 ## Enabling keyboard navigation
 For security reasons ssh-askpass defaults to cancel since it's too easy to

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Used to accept (or deny) the use of the private key(s) added to the SSH authenti
 ```
 $ sudo cp ssh-askpass /usr/local/bin/
 $ cp ssh-askpass.plist ~/Library/LaunchAgents/
-
 ```
 * Log out and in (reboot preferrd) before you can add keys to the agent with `ssh-add -c`
 

--- a/ssh-askpass
+++ b/ssh-askpass
@@ -14,10 +14,6 @@
 # OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 # PERFORMANCE OF THIS SOFTWARE.
 
-# Installation:
-# sudo ln -s $PWD/ssh-askpass /usr/libexec/ssh-askpass
-# chmod +x /usr/libexec/ssh-askpass
-
 on run argv
     set args to argv as text
     set frontmost_application to name of (info for (path to frontmost application))

--- a/ssh-askpass.plist
+++ b/ssh-askpass.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
     <dict>
         <key>Label</key>
-        <string>com.openssh.ssh-agent-ssh-askpass</string>
+        <string>com.github.theseal.ssh-askpass</string>
         <key>ProgramArguments</key>
         <array>
             <string>/usr/bin/ssh-agent</string>

--- a/ssh-askpass.plist
+++ b/ssh-askpass.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Label</key>
+        <string>com.openssh.ssh-agent-ssh-askpass</string>
+        <key>ProgramArguments</key>
+        <array>
+            <string>/usr/bin/ssh-agent</string>
+            <string>-l</string>
+        </array>
+        <key>EnvironmentVariables</key>
+        <dict>
+            <key>SSH_ASKPASS</key>
+            <string>/usr/local/bin/ssh-askpass</string>
+            <key>DISPLAY</key>
+            <string>0</string>
+        </dict>
+        <key>Sockets</key>
+        <dict>
+            <key>Listeners</key>
+            <dict>
+                <key>SecureSocketWithKey</key>
+                <string>SSH_AUTH_SOCK</string>
+            </dict>
+        </dict>
+        <key>EnableTransactions</key>
+        <true/>
+    </dict>
+</plist>


### PR DESCRIPTION
Idea from @bharrisau in #11.
Launch the ssh-agent with the correct variables with launchd.
 

This closes #11 aswell.