### PR TITLE
Use "System Events" instead of whatever app is frontmost

### DIFF
--- a/ssh-askpass
+++ b/ssh-askpass
@@ -1,4 +1,4 @@
-#!/usr/bin/env osascript
+#!/usr/bin/osascript
 # Copyright (c) 2014-, Johan Wassberg <johan@rymdvarel.se>
 # Copyright (c) 2011-, Simon Lundström <simmel@soy.se>
 #
@@ -16,8 +16,7 @@
 
 on run argv
     set args to argv as text
-    set frontmost_application to name of (info for (path to frontmost application))
-    tell application frontmost_application
+    tell application "System Events"
         if args ends with ": " or args ends with ":" then
             if args contains "pass" or args contains "pin" then
                 display dialog args with icon caution default button {get localized string of "OK"} default answer "" with hidden answer


### PR DESCRIPTION
Target the "System Events" application instead of whatever app happens to be frontmost at the time. This ensures that the password is being typed in to a system process, and not just any random app. This should alsö improve reliability as the System Events app is explicitly provided by macOS for this exact purpose. 

Alsö, this script is not portable; there's no need to use "env" to launch "osascript". Apple Events literally can only happen on a Mac, and osascript isn't going anywhere.

Fixes #25 