### PR TITLE
Rewrite plist to not override Apple's ssh-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Used to accept (or deny) the use of the private key(s) added to the SSH authenti
 $ cp ssh-askpass /usr/local/bin/
 $ cp ssh-askpass.plist ~/Library/LaunchAgents/
 $ launchctl load -w ~/Library/LaunchAgents/ssh-askpass.plist
-$ launchctl stop com.openssh.ssh-agent
 ```
 * No need to log out; you can add keys to the agent with `ssh-add -c`
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ Used to accept (or deny) the use of the private key(s) added to the SSH authenti
 ```
 $ cp ssh-askpass /usr/local/bin/
 $ cp ssh-askpass.plist ~/Library/LaunchAgents/
+$ launchctl load -w ~/Library/LaunchAgents/ssh-askpass.plist
+$ launchctl stop com.openssh.ssh-agent
 ```
-* Log out and in before you can add keys to the agent with `ssh-add -c`
+* No need to log out; you can add keys to the agent with `ssh-add -c`
 
 ## Enabling keyboard navigation
 For security reasons ssh-askpass defaults to cancel since it's too easy to

--- a/ssh-askpass.plist
+++ b/ssh-askpass.plist
@@ -13,6 +13,7 @@
             <string>#!/bin/sh
 launchctl setenv SSH_ASKPASS "${SSH_ASKPASS:=/usr/local/bin/ssh-askpass}"
 launchctl setenv DISPLAY "${DISPLAY:=0}" # only if not already set by Xquartz
+launchctl stop com.openssh.ssh-agent # to make sure it picks up environment
             </string>
         </array>
         <key>RunAtLoad</key>

--- a/ssh-askpass.plist
+++ b/ssh-askpass.plist
@@ -4,6 +4,8 @@
     <dict>
         <key>Label</key>
         <string>com.github.theseal.ssh-askpass</string>
+        <key>LimitLoadToSessionType</key>
+        <string>Aqua</string>
         <key>ProgramArguments</key>
         <array>
             <string>/bin/sh</string>

--- a/ssh-askpass.plist
+++ b/ssh-askpass.plist
@@ -6,25 +6,14 @@
         <string>com.github.theseal.ssh-askpass</string>
         <key>ProgramArguments</key>
         <array>
-            <string>/usr/bin/ssh-agent</string>
-            <string>-l</string>
+            <string>/bin/sh</string>
+            <string>-pc</string>
+            <string>#!/bin/sh
+launchctl setenv SSH_ASKPASS "${SSH_ASKPASS:=/usr/local/bin/ssh-askpass}"
+launchctl setenv DISPLAY "${DISPLAY:=0}" # only if not already set by Xquartz
+            </string>
         </array>
-        <key>EnvironmentVariables</key>
-        <dict>
-            <key>SSH_ASKPASS</key>
-            <string>/usr/local/bin/ssh-askpass</string>
-            <key>DISPLAY</key>
-            <string>0</string>
-        </dict>
-        <key>Sockets</key>
-        <dict>
-            <key>Listeners</key>
-            <dict>
-                <key>SecureSocketWithKey</key>
-                <string>SSH_AUTH_SOCK</string>
-            </dict>
-        </dict>
-        <key>EnableTransactions</key>
+        <key>RunAtLoad</key>
         <true/>
     </dict>
 </plist>


### PR DESCRIPTION
Set the SSH_ASKPASS environment for the whole user session, not just for the ssh-agent process. Alsö, don't replace Apple's existing ssh-agent LaunchAgent. Likewise, only set the variable(s) if not already set.

Alsö, this PR fixes #23.

(e74c6749d5a0cf0cedfd822fc7a94a387d329408 fixes #24 by removing the erroneous "sudo" message from brew)