### PR TITLE
Always use System Events

### DIFF
--- a/ssh-askpass
+++ b/ssh-askpass
@@ -16,7 +16,6 @@
 
 on run argv
     set args to argv as text
-    launch application "System Events"
     set agent to POSIX file "/System/Applications/Utilities/Terminal.app/Contents/Resources/Terminal.icns"
     try
         tell application "System Events"

--- a/ssh-askpass
+++ b/ssh-askpass
@@ -27,12 +27,11 @@ on run argv
                     display dialog args with icon agent default button {get localized string of "OK"} default answer ""
                 end if
                 set text_returned to result's text returned
-                quit
             else
                 display dialog args with icon agent default button {get localized string of "Cancel"}
                 set text_returned to ""
-                quit
             end if
+            quit
         end tell
         return text_returned
     on error e number n

--- a/ssh-askpass
+++ b/ssh-askpass
@@ -33,7 +33,11 @@ on run argv
             end if
             quit
         end tell
-        return text_returned
+        if text_returned is not "" then
+            return text_returned
+        else
+            return
+        end if
     on error e number n
         tell application "System Events" to quit
         error e

--- a/ssh-askpass
+++ b/ssh-askpass
@@ -16,19 +16,27 @@
 
 on run argv
     set args to argv as text
-    set frontmost_application to name of (info for (path to frontmost application))
+    launch application "System Events"
     set agent to POSIX file "/System/Applications/Utilities/Terminal.app/Contents/Resources/Terminal.icns"
-    tell application frontmost_application
-        if args ends with ": " or args ends with ":" then
-            if args contains "pass" or args contains "pin" then
-                tell application "System Events" to display dialog args with icon agent default button {get localized string of "OK"} default answer "" with hidden answer
+    try
+        tell application "System Events"
+            if args ends with ": " or args ends with ":" then
+                if args contains "pass" or args contains "pin" then
+                    set response to display dialog args with icon agent default button {get localized string of "OK"} default answer "" with hidden answer
+                else
+                    set response to display dialog args with icon agent default button {get localized string of "OK"} default answer ""
+                end if
+                set text_returned to text returned of response
+                quit
             else
-                display dialog args with icon agent default button {get localized string of "OK"} default answer ""
+                set response to display dialog args with icon agent default button {get localized string of "Cancel"}
+                set text_returned to ""
+                quit
             end if
-            return result's text returned
-        else
-            display dialog args with icon agent default button {get localized string of "Cancel"}
-            return
-        end if
-    end tell
+        end tell
+        return text_returned
+    on error e number n
+        tell application "System Events" to quit
+        error e
+    end try
 end run

--- a/ssh-askpass
+++ b/ssh-askpass
@@ -22,14 +22,14 @@ on run argv
         tell application "System Events"
             if args ends with ": " or args ends with ":" then
                 if args contains "pass" or args contains "pin" then
-                    set response to display dialog args with icon agent default button {get localized string of "OK"} default answer "" with hidden answer
+                    display dialog args with icon agent default button {get localized string of "OK"} default answer "" with hidden answer
                 else
-                    set response to display dialog args with icon agent default button {get localized string of "OK"} default answer ""
+                    display dialog args with icon agent default button {get localized string of "OK"} default answer ""
                 end if
-                set text_returned to text returned of response
+                set text_returned to result's text returned
                 quit
             else
-                set response to display dialog args with icon agent default button {get localized string of "Cancel"}
+                display dialog args with icon agent default button {get localized string of "Cancel"}
                 set text_returned to ""
                 quit
             end if


### PR DESCRIPTION
Tell System Events to get out of the way once it's done to ensure that keyboard focus returns to wherever it was before.
This ensures that (1) System Events is running, (2) that it quits after the dialog, (3) that the dialog text is returned even after System Events quits, and (4) that the `osascript` tool returns an error code when "cancel" is selected.

Using the frontmost application for interaction is an endless rabbithole of edge cases and errors. It seems convenient but it is not a good design.

Closes #25 .