### PR TITLE
Add SUDO_ASKPASS to environment variables

### DIFF
--- a/ssh-askpass.plist
+++ b/ssh-askpass.plist
@@ -12,7 +12,8 @@
             <string>-pc</string>
             <string>#!/bin/sh
 launchctl setenv SSH_ASKPASS "${SSH_ASKPASS:=/usr/local/bin/ssh-askpass}"
-launchctl setenv DISPLAY "${DISPLAY:=0}" # only if not already set by Xquartz
+launchctl setenv SUDO_ASKPASS "${SUDO_ASKPASS:=/usr/local/bin/ssh-askpass}"
+launchctl list org.xquartz.startx >/dev/null || launchctl setenv DISPLAY "${DISPLAY:=ssh-askpass}" # only if not already set by Xquartz
 launchctl stop com.openssh.ssh-agent # to make sure it picks up environment
             </string>
         </array>


### PR DESCRIPTION
Alsö also, set DISPLAY to something nonsensical to avoid the possibility of setting it to a valid but undesired value. (E.g., if another user is logged in and has `DISPLAY=0`, but the current user doesn’t have XQuartz running, we don’t want to inadvertantly tell this user’s X apps to appear on the other user’s XQuartz. Or, Xvnc &c.)