### PR TITLE
Change dialog icon from Terminal to 'stop'

### DIFF
--- a/ssh-askpass
+++ b/ssh-askpass
@@ -17,19 +17,18 @@
 on run argv
     set args to argv as text
     launch application "System Events"
-    set agent to POSIX file "/System/Applications/Utilities/Terminal.app/Contents/Resources/Terminal.icns"
     set dialog_timeout to 15
     try
         tell application "System Events"
             if args ends with ": " or args ends with ":" then
                 if args contains "pass" or args contains "pin" then
-                    display dialog args with icon agent default button {get localized string of "OK"} default answer "" with hidden answer
+                    display dialog args with icon stop default button {get localized string of "OK"} default answer "" with hidden answer
                 else
-                    display dialog args with icon agent default button {get localized string of "OK"} default answer ""
+                    display dialog args with icon stop default button {get localized string of "OK"} default answer ""
                 end if
                 set text_returned to result's text returned
             else
-                display dialog args with icon agent default button {get localized string of "Cancel"} giving up after dialog_timeout
+                display dialog args with icon stop default button {get localized string of "Cancel"} giving up after dialog_timeout
                 if gave up of result then
                     error result
                 end if


### PR DESCRIPTION
I'm using `ssh-askpass` with [QtPass](https://qtpass.org/). On my machine running High Sierra, hitting the "git pull" button in the QtPass toolbar produces the following ssh-askpass error:
```
/usr/local/bin/ssh-askpass:2141:2142: execution error: System Events got an error: 
Can’t make file "Macintosh HD:System:Applications:Utilities:Terminal.app:Contents:Resources:Terminal.icns" into type number or string. (-2700)
```
Rather than try to figure out what broke with the icon extraction, I changed the script to use the built-in "stop" icon.

Works on My Machine™ tested.

Thanks for this code, and hopefully for accepting this change!