### PR TITLE
use old Terminal path for macOS < 10.15

### DIFF
--- a/ssh-askpass
+++ b/ssh-askpass
@@ -17,7 +17,14 @@
 on run argv
     set args to argv as text
     launch application "System Events"
-    set agent to POSIX file "/System/Applications/Utilities/Terminal.app/Contents/Resources/Terminal.icns"
+    considering numeric strings
+        set pre_catalina to (system version of (system info)) < "10.15"
+    end considering
+    if pre_catalina then
+        set agent to POSIX file "/Applications/Utilities/Terminal.app/Contents/Resources/Terminal.icns"
+    else
+        set agent to POSIX file "/System/Applications/Utilities/Terminal.app/Contents/Resources/Terminal.icns"
+    end if
     set dialog_timeout to 15
     try
         tell application "System Events"


### PR DESCRIPTION
fixes #46