### PR TITLE
add stuff to handle prompts

### DIFF
--- a/ssh-askpass
+++ b/ssh-askpass
@@ -33,6 +33,9 @@ on run argv
             display dialog args with icon agent default button {get localized string of "OK"} default answer ""
         end if
         return result's text returned
+    else if args contains "host" then
+            display dialog args with icon agent buttons {"No", "Yes"}
+            return result's text
     else
         display dialog args with icon agent default button 1 giving up after dialog_timeout
         if gave up of result then


### PR DESCRIPTION
This handles host key prompting which doesn't work. I'm not sure if this is super robust, or if there are other unhandled prompts