### PR TITLE
Update instructions for Sonoma 14.6+ (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Used to accept (or deny) the use of the private key(s) added to the SSH authenti
    ```sh
    sudo port install ssh-askpass
    sudo mkdir -p /private/var/select/X11/bin
-   sudo ln -s /usr/local/bin/ssh-askpass /private/var/select/X11/bin/
+   sudo ln -s /opt/local/bin/ssh-askpass /private/var/select/X11/bin/
    ```
 
 ### Without Homebrew/MacPorts

--- a/ssh-askpass.plist
+++ b/ssh-askpass.plist
@@ -11,10 +11,8 @@
             <string>/bin/sh</string>
             <string>-pc</string>
             <string>#!/bin/sh
-launchctl setenv SSH_ASKPASS "${SSH_ASKPASS:=/usr/local/bin/ssh-askpass}"
-launchctl setenv SUDO_ASKPASS "${SUDO_ASKPASS:=/usr/local/bin/ssh-askpass}"
-launchctl list org.xquartz.startx >/dev/null || launchctl setenv DISPLAY "${DISPLAY:=ssh-askpass}" # only if not already set by Xquartz
-launchctl stop com.openssh.ssh-agent # to make sure it picks up environment
+launchctl setenv SSH_ASKPASS "${SSH_ASKPASS:=/private/var/select/X11/bin/ssh-askpass}"
+launchctl setenv SUDO_ASKPASS "${SUDO_ASKPASS:=/private/var/select/X11/bin/ssh-askpass}"
             </string>
         </array>
         <key>RunAtLoad</key>


### PR DESCRIPTION
Fixes #54 (well, works around the new normal).

This documents [the workarounds I've provided here](https://github.com/theseal/ssh-askpass/issues/54#issuecomment-2268376357), which is the **only** way that works with Apple's stock `ssh-agent` LaunchAgent configuration and [does not rely on exploiting `launchd` security weaknesses](https://github.com/theseal/ssh-askpass/issues/54#issuecomment-2277847990).

The Homebrew formula will need to be updated to patch the new default paths in the plist: https://github.com/theseal/homebrew-ssh-askpass/pull/20

I've made a couple of changes to the plist, because they have no effect on Apple `ssh-agent` Sonoma 14.6 and later:

* Remove setting `DISPLAY` with `launchctl setenv`
* Don't stop `com.openssh.ssh-agent` (Apple's `ssh-agent`)

The Homebrew formula could be replaced with a cask to automate this stuff. I'll add an issue for that later.

This should work even if you installed your own `ssh-agent` to replace Apple's, as long as it checks `/usr/X11R6/bin/ssh-askpass`.

While this doesn't fix usage of third-party authentication modules like FIDO2, that's totally unrelated to `ssh-askpass`.

## Feedback needed

* [x] ~~This assumes that MacPorts always installs to `/usr/local/bin`.  Homebrew uses different paths on Apple Silicon and Intel.~~ It's been `/opt/local` for at least a decade, fixed.
